### PR TITLE
checkAndMakeInputData 리팩토링

### DIFF
--- a/client/src/components/Signup/Signup.ts
+++ b/client/src/components/Signup/Signup.ts
@@ -26,6 +26,7 @@ class Signup extends Component<IProps, IState> {
     ) as HTMLInputElement[]
 
     const signupBody = checkAndmakeInputData(inputs)
+    console.log(signupBody)
     if (!signupBody) return
 
     const [signUpResponse, signUpError] = await signUp(signupBody)

--- a/client/src/utils/authorization.ts
+++ b/client/src/utils/authorization.ts
@@ -6,9 +6,23 @@ export function validateId(target: HTMLInputElement) {
 }
 
 export function validatePassword(target: HTMLInputElement) {
-  if (!target.value.length) {
+  const firstPassword = target.value
+  if (!firstPassword.length) {
     return false
   }
+  const $secondPassword = target
+    .closest('div')
+    .nextElementSibling.querySelector('input')
+
+  const secondPassword = $secondPassword.value
+  const $validatePasswordError = $secondPassword.nextElementSibling
+
+  if (firstPassword !== secondPassword) {
+    $validatePasswordError.classList.add('visible')
+  } else {
+    $validatePasswordError.classList.remove('visible')
+  }
+
   return true
 }
 

--- a/client/src/utils/authorization.ts
+++ b/client/src/utils/authorization.ts
@@ -28,11 +28,20 @@ export function validatePasswordOverlap(target: HTMLInputElement) {
 
 export function checkAndmakeInputData(inputs) {
   const body = {}
+
   for (let i = 0; i < inputs.length; i++) {
     if (!inputs[i].value.length) {
       const $errorElement = inputs[i].nextElementSibling
       $errorElement.classList.add('visible')
       return inputs[i].focus()
+    }
+
+    if (inputs[i].name === 'passwordCheck') {
+      const firstPassword = inputs[i - 1].value
+      const secondPassword = inputs[i].value
+      if (firstPassword !== secondPassword) {
+        return inputs[i].select()
+      }
     }
 
     body[inputs[i].name] = inputs[i].value

--- a/client/src/utils/authorization.ts
+++ b/client/src/utils/authorization.ts
@@ -30,13 +30,12 @@ export function checkAndmakeInputData(inputs) {
   const body = {}
   for (let i = 0; i < inputs.length; i++) {
     if (!inputs[i].value.length) {
-      inputs[i].nextElementSibling.classList.add('visible')
+      const $errorElement = inputs[i].nextElementSibling
+      $errorElement.classList.add('visible')
       return inputs[i].focus()
     }
 
-    inputs.forEach((input) => {
-      body[input.name] = input.value
-    })
+    body[inputs[i].name] = inputs[i].value
   }
   return body
 }


### PR DESCRIPTION
## checkAndMakeInputData 리팩토링

* 이중 for문 문제 해결
* errorElement 변수화

### inputs의 유효성을 검사하면서 body data를 만들 때 비밀번호 확인의 경우를 분기 처리

* 다른 경우는 길이가 없으면 오류

* 하지만 비밀번호 확인의 경우 그 전 값과 비교를 해야하기 때문에 따로 처리를 해줘야한다.

* 이미 값이 있는데 오류가 나오기 때문에 focus가 아닌 select 선택

### validatePassword 수정

* 기존에는 비밀번호를 입력하고 비밀번호 확인에 맞지 않는 값을 넣고 비밀번호를 고쳐도 계속 오류라고 뜸

* 즉, 비밀번호와 비밀번호를 비교하는 로직을 validatepassword에서도 확인해야한다.

* 따라서, validatePassword안에 비교하는 로직 추가

* 비교하고 error 보이게하는 로직까지 추가