### PR TITLE
Feat/56 update routing

### DIFF
--- a/client/src/modules/MonthStore.ts
+++ b/client/src/modules/MonthStore.ts
@@ -1,21 +1,24 @@
-import { Store } from '../utils/wooact/Store'
+import { Store } from '../utils/Store'
+import { fireEvent, STORE_UPDATED } from '../utils/customEventHandler'
 
 // type
-export interface IMonth {
-  month: number
-}
+export type Month = number
 
 // actions
 export const CHANGE_MONTH = 'Month/CHANGE_MONTH' as const
 
 // connect store and actions
-export class MonthStore extends Store<IMonth> {
+export class MonthStore extends Store<Month> {
   actions = {
     [CHANGE_MONTH]: this.changeMonth,
   }
 
-  constructor() {
-    super({ month: new Date().getMonth() })
+  constructor(initialData: Month) {
+    super(initialData)
+    // TODO is this right?
+    // window.dispatchEvent(
+    //   new CustomEvent('storeupdated', { detail: { month: initialData } })
+    // )
   }
 
   // actions
@@ -26,8 +29,13 @@ export class MonthStore extends Store<IMonth> {
   protected updateStore(action: string, result: any) {
     switch (action) {
       case CHANGE_MONTH:
-        this._data = { ...this._data, ...result }
+        this._data = result
         break
     }
+
+    // window.dispatchEvent(
+    //   new CustomEvent('storeupdated', { detail: { month: this.data } })
+    // )
+    fireEvent(STORE_UPDATED, { month: this.data })
   }
 }

--- a/client/src/modules/TransactionStore.ts
+++ b/client/src/modules/TransactionStore.ts
@@ -4,7 +4,7 @@ import {
   createNewTransaction,
   ICreateTransaction,
 } from '../api/transaction'
-import { Store } from '../utils/wooact/Store'
+import { Store } from '../utils/Store'
 
 // actions
 export const FETCH_ALL_TRANSACTION = 'Transaction/FETCH_ALL' as const
@@ -40,6 +40,7 @@ export class TransactionStore extends Store<ITransactionResponse[]> {
   }
 
   protected updateStore(action: string, result: any) {
+    let isUpdated = true
     switch (action) {
       case FETCH_ALL_TRANSACTION:
         this._data = [...result]
@@ -47,6 +48,12 @@ export class TransactionStore extends Store<ITransactionResponse[]> {
       case ADD_ONE_TRANSACTION:
         this._data = [...this._data, result]
         break
+      default:
+        isUpdated = false
     }
+
+    // window.dispatchEvent(
+    //   new CustomEvent('storeupdated', { detail: { transaction: this.data } })
+    // )
   }
 }

--- a/client/src/modules/TransactionStore.ts
+++ b/client/src/modules/TransactionStore.ts
@@ -40,7 +40,6 @@ export class TransactionStore extends Store<ITransactionResponse[]> {
   }
 
   protected updateStore(action: string, result: any) {
-    let isUpdated = true
     switch (action) {
       case FETCH_ALL_TRANSACTION:
         this._data = [...result]
@@ -48,8 +47,6 @@ export class TransactionStore extends Store<ITransactionResponse[]> {
       case ADD_ONE_TRANSACTION:
         this._data = [...this._data, result]
         break
-      default:
-        isUpdated = false
     }
 
     // window.dispatchEvent(

--- a/client/src/modules/index.ts
+++ b/client/src/modules/index.ts
@@ -1,17 +1,27 @@
-import { Store } from '../utils/wooact/Store'
+import { Store } from '../utils/Store'
 import { TransactionStore } from './TransactionStore'
-import { IMonth, MonthStore } from './MonthStore'
+import { Month, MonthStore } from './MonthStore'
 import { ITransactionResponse } from '../api/transaction'
+import { fireEvent, STORE_UPDATED } from '../utils/customEventHandler'
 
 export interface ICombinedStore {
   transaction: Store<ITransactionResponse[]>
-  month: Store<IMonth>
+  month: Store<Month>
 }
 
+const initialMonth = new Date().getMonth() + 1
+
 const transactionStore = new TransactionStore()
-const monthStore = new MonthStore()
+const monthStore = new MonthStore(initialMonth)
 
 export const combinedStore: ICombinedStore = {
   transaction: transactionStore,
   month: monthStore,
 }
+
+// export const combinedStoreData = {
+//   transaction: { updated: false, data: transactionStore.data },
+//   month: { updated: false, data: monthStore.data },
+// }
+
+// fireEvent(STORE_UPDATED, { month: initialMonth })

--- a/client/src/modules/index.ts
+++ b/client/src/modules/index.ts
@@ -2,7 +2,6 @@ import { Store } from '../utils/Store'
 import { TransactionStore } from './TransactionStore'
 import { Month, MonthStore } from './MonthStore'
 import { ITransactionResponse } from '../api/transaction'
-import { fireEvent, STORE_UPDATED } from '../utils/customEventHandler'
 
 export interface ICombinedStore {
   transaction: Store<ITransactionResponse[]>

--- a/client/src/utils/Store.ts
+++ b/client/src/utils/Store.ts
@@ -1,5 +1,5 @@
-import { Component } from '.'
-import { Diffing } from './Diffing'
+import { Component } from './wooact'
+import { Routing } from './Routing'
 
 interface IActions {
   [actionName: string]: (args: any) => Promise<any> | any
@@ -21,6 +21,7 @@ export abstract class Store<T> {
     }
 
     const result = selectedAction(args)
+
     if (result instanceof Promise) {
       this.updateStore(action, await result)
     } else {
@@ -31,14 +32,17 @@ export abstract class Store<T> {
   }
 
   subscribe(component: Component<any, any>): Store<T> {
+    this.subscribedComponent = this.subscribedComponent.filter(
+      (c) => c.constructor !== component.constructor
+    )
+
     this.subscribedComponent.push(component)
     return this
   }
 
-  unSubscribe(component: Component<any, any>) {
-    this.subscribedComponent = this.subscribedComponent.filter(
-      (c) => c !== component
-    )
+  injectData(caller: Routing, data: T) {
+    this._data = data
+    this.rerender()
   }
 
   get data(): T {

--- a/client/src/utils/customEventHandler.ts
+++ b/client/src/utils/customEventHandler.ts
@@ -1,0 +1,23 @@
+export const STORE_UPDATED = 'STORE_UPDATED' as const
+export const POP_STATE = 'popstate' as const
+
+const eventSet = new Set()
+
+export const listenEvent = (eventName: string, cb: (e?) => void) => {
+  if (eventSet.has(eventName)) {
+    console.error('Already existed Event')
+    return
+  }
+
+  eventSet.add(eventName)
+  window.addEventListener(eventName, cb)
+}
+
+export const fireEvent = (eventName: string, detail: any) => {
+  if (!eventSet.has(eventName)) {
+    console.error('None existed event')
+    return
+  }
+
+  window.dispatchEvent(new CustomEvent(eventName, { detail }))
+}

--- a/client/src/utils/wooact/Component.ts
+++ b/client/src/utils/wooact/Component.ts
@@ -1,5 +1,5 @@
 import { Diffing } from './Diffing'
-import { Store } from './Store'
+import { Store } from '../Store'
 import { Routing } from '../../utils/Routing'
 import { ICombinedStore, combinedStore } from '../../modules'
 


### PR DESCRIPTION
`history.pushState`를 통해 해당 상태값을 저장하는 부분 구현 하는 중

전체 상태값을 저장하지않고 개별적인 상태값을 따로 저장하기 때문에 효율적이지 못함
전체 데이터를 한번에 관리하는 방법을 생각해야함