### PR TITLE
Refactor/74 data handling

### DIFF
--- a/client/src/api/transaction.ts
+++ b/client/src/api/transaction.ts
@@ -1,6 +1,5 @@
 import { fetchWrapper } from '../utils/fetchWrapper'
 import { TRANSACTION } from './apiRoutes'
-import { addTimeDiff } from '../utils/timeAdjust'
 
 export interface ICreateTransaction {
   content: string

--- a/client/src/api/transaction.ts
+++ b/client/src/api/transaction.ts
@@ -1,5 +1,6 @@
 import { fetchWrapper } from '../utils/fetchWrapper'
 import { TRANSACTION } from './apiRoutes'
+import { addTimeDiff } from '../utils/timeAdjust'
 
 export interface ICreateTransaction {
   content: string
@@ -7,6 +8,10 @@ export interface ICreateTransaction {
   paymentId: number
   userId: number
   categoryId: number
+}
+
+export interface IUpdateTransaction extends Partial<ICreateTransaction> {
+  id: number
 }
 
 export interface ITransactionResponse {
@@ -20,10 +25,11 @@ export interface ITransactionResponse {
   iconName: string
 }
 
-export const fetchAllTransaction = async () => {
+export const fetchAllTransaction = async (year: number, month: number) => {
+  const date = `${year}-${month}`
   return await fetchWrapper<ITransactionResponse[], undefined>(
     'GET',
-    TRANSACTION
+    TRANSACTION + `/${date}`
   )
 }
 
@@ -32,5 +38,20 @@ export const createNewTransaction = async (args: ICreateTransaction) => {
     'POST',
     TRANSACTION,
     args
+  )
+}
+
+export const updateTransaction = async (args: IUpdateTransaction) => {
+  return await fetchWrapper<ITransactionResponse, IUpdateTransaction>(
+    'PUT',
+    TRANSACTION,
+    args
+  )
+}
+
+export const deleteTransaction = async (id: number) => {
+  return await fetchWrapper<ITransactionResponse, IUpdateTransaction>(
+    'PUT',
+    TRANSACTION + `/${id}`
   )
 }

--- a/client/src/components/App/App.ts
+++ b/client/src/components/App/App.ts
@@ -14,13 +14,17 @@ class App extends Component<IProps, IState> {
     super(props)
 
     Object.setPrototypeOf(this, App.prototype)
-    this.connectStore('transaction', 'category', 'visible')
+    this.connectAction('transaction', 'category')
     routing.init(this)
     this.init()
   }
 
   async componentDidMount() {
-    this.store.transaction.dispatch(FETCH_ALL_TRANSACTION)
+    const today = new Date()
+    this.store.transaction.dispatch(FETCH_ALL_TRANSACTION, {
+      month: today.getMonth() + 1,
+      year: today.getFullYear(),
+    })
     this.store.category.dispatch(FETCH_ALL_CATEGORIES)
   }
 

--- a/client/src/components/Header/Header.ts
+++ b/client/src/components/Header/Header.ts
@@ -2,6 +2,7 @@ import { Component } from '../../utils/wooact'
 import { header, h1, div, span } from '../../utils/wooact/defaultElements'
 import { ICon } from '../ICon'
 import { TOGGLE_INCOME, TOGGLE_OUTCOME } from '../../modules/visibleStore'
+import { getCSVNumber } from '../../utils/getCSVNumber'
 
 interface IProps {
   title: string
@@ -55,7 +56,7 @@ class Header extends Component<IProps, IState> {
       },
       div({
         className: `price-sum ${key} ${visible.data[key] ? 'selected' : ''}`,
-        textContent: priceSum.toString(),
+        textContent: getCSVNumber(priceSum),
       }),
       new ICon({
         isSelected: visible.data[key],
@@ -69,8 +70,6 @@ class Header extends Component<IProps, IState> {
 
   render() {
     this.prepareData()
-    console.log(this.sumOfIncome)
-    console.log(this.sumOfOutcome)
 
     return header(
       { className: 'header-container' },

--- a/client/src/components/ICon/ICon.ts
+++ b/client/src/components/ICon/ICon.ts
@@ -2,10 +2,10 @@ import { Component } from '../../utils/wooact'
 import { div, i } from '../../utils/wooact/defaultElements'
 
 interface IProps {
-  isSelected: boolean
+  isSelected?: boolean
   onClickHandler: () => void
   isIncome?: boolean
-  name: string
+  name?: string
   iconName: string
 }
 interface IState {}
@@ -32,7 +32,7 @@ class ICon extends Component<IProps, IState> {
         className: `f7-icons ${iconClass}`,
         textContent: iconName,
       }),
-      div({ className: 'icon-description', textContent: name })
+      name ? div({ className: 'icon-description', textContent: name }) : null
     )
   }
 }

--- a/client/src/components/SideBar/SideBar.ts
+++ b/client/src/components/SideBar/SideBar.ts
@@ -9,6 +9,7 @@ import {
   TRANSACTION,
 } from '../../utils/Routing'
 import { MONTH_IN_ENG } from '../../utils/dateInfos'
+import { FETCH_ALL_TRANSACTION } from '../../modules/TransactionStore'
 
 interface IProps {}
 interface IState {
@@ -27,8 +28,46 @@ class SideBar extends Component<IProps, IState> {
     super({}, state)
 
     Object.setPrototypeOf(this, SideBar.prototype)
-    this.connectStore('transaction')
+    this.connectAction('transaction')
     this.init()
+  }
+
+  async fetchTransactions() {
+    const currentMonth = this.getState('month')
+    const currentYear = this.getState('year')
+
+    await this.store.transaction.dispatch(FETCH_ALL_TRANSACTION, {
+      month: currentMonth,
+      year: currentYear,
+    })
+  }
+
+  async setNextMonth() {
+    const currentMonth = this.getState('month')
+    const currentYear = this.getState('year')
+
+    if (currentMonth === 12) {
+      this.setState('month', 1)
+      this.setState('year', currentYear + 1)
+    } else {
+      this.setState('month', currentMonth + 1)
+    }
+
+    await this.fetchTransactions()
+  }
+
+  async setPrevMonth() {
+    const currentMonth = this.getState('month')
+    const currentYear = this.getState('year')
+
+    if (currentMonth === 1) {
+      this.setState('month', 12)
+      this.setState('year', currentYear - 1)
+    } else {
+      this.setState('month', currentMonth - 1)
+    }
+
+    await this.fetchTransactions()
   }
 
   renderMainIcon() {
@@ -51,6 +90,10 @@ class SideBar extends Component<IProps, IState> {
       {
         className: 'date-container',
       },
+      new ICon({
+        onClickHandler: () => this.setPrevMonth(),
+        iconName: 'arrow_left',
+      }),
       div({
         className: 'year',
         textContent: year.toString(),
@@ -62,6 +105,10 @@ class SideBar extends Component<IProps, IState> {
       div({
         className: 'month-eng',
         textContent: MONTH_IN_ENG[month - 1],
+      }),
+      new ICon({
+        onClickHandler: () => this.setNextMonth(),
+        iconName: 'arrow_right',
       })
     )
   }
@@ -75,7 +122,6 @@ class SideBar extends Component<IProps, IState> {
         new ICon({
           isSelected: routing.getPath() === route,
           onClickHandler: () => routing.pushTo(route),
-          name: '',
           iconName: icons[idx],
         })
     )

--- a/client/src/components/TransactionList/TransactionList.ts
+++ b/client/src/components/TransactionList/TransactionList.ts
@@ -3,7 +3,6 @@ import { div, p, data } from '../../utils/wooact/defaultElements'
 import { ITransactionResponse } from '../../api/transaction'
 import { TransactionItem } from '../TransactionItem'
 import { getCSVNumber } from '../../utils/getCSVNumber'
-import { FETCH_ALL_TRANSACTION } from '../../modules/TransactionStore'
 import { getRecordedDate, filterByDate } from '../../utils/dataFilterer'
 interface IProps {}
 interface IState {}

--- a/client/src/modules/TransactionStore.ts
+++ b/client/src/modules/TransactionStore.ts
@@ -21,8 +21,12 @@ export class TransactionStore extends Store<ITransactionResponse[]> {
     super(initData || null)
   }
 
-  async fetchAllTransactions() {
-    const [fetchedTransactions, fetchError] = await fetchAllTransaction()
+  async fetchAllTransactions(args: { year: number; month: number }) {
+    const { year, month } = args
+    const [fetchedTransactions, fetchError] = await fetchAllTransaction(
+      year,
+      month
+    )
     if (fetchError) {
       return console.error(fetchError)
     }

--- a/client/src/utils/Store.ts
+++ b/client/src/utils/Store.ts
@@ -31,7 +31,11 @@ export abstract class Store<T> {
     this.rerender()
   }
 
-  subscribe(component: Component<any, any>): Store<T> {
+  subscribe(component?: Component<any, any>): Store<T> {
+    if (!component) {
+      return this
+    }
+
     this.subscribedComponent = this.subscribedComponent.filter(
       (c) => c.constructor !== component.constructor
     )

--- a/client/src/utils/wooact/Component.ts
+++ b/client/src/utils/wooact/Component.ts
@@ -67,6 +67,13 @@ abstract class Component<P, S> {
     })
   }
 
+  protected connectAction(...storeNames: (keyof ICombinedStore)[]) {
+    storeNames.forEach((storeName) => {
+      // TODO need to fix!
+      this.store[storeName] = combinedStore[storeName].subscribe() as any
+    })
+  }
+
   // callable by outside of component, but only restricted to Store or Routing
   // and if it has a
   public reRenderBy(caller: Store<any> | Routing, partialState?: Partial<S>) {

--- a/server/src/routes/transaction-routes.ts
+++ b/server/src/routes/transaction-routes.ts
@@ -3,8 +3,13 @@ import { validateBody } from "../middlewares/validate-body";
 import {
 	createNewTransaction,
 	getAllTransactions,
+	updateTransaction,
+	deleteTransaction,
 } from "../service/transaction-service";
-import { ICreateTransaction } from "../repository/transaction-repository";
+import {
+	ICreateTransaction,
+	IUpdateTransaction,
+} from "../repository/transaction-repository";
 
 const transactionRouter = Router();
 
@@ -20,6 +25,12 @@ transactionRouter.post(
 	createNewTransaction
 );
 
-transactionRouter.get("/", getAllTransactions);
+transactionRouter.get("/:date", getAllTransactions);
+transactionRouter.put(
+	"/",
+	validateBody<IUpdateTransaction>(["id"]),
+	updateTransaction
+);
+transactionRouter.delete("/:id", deleteTransaction);
 
 export default transactionRouter;

--- a/server/src/service/transaction-service.ts
+++ b/server/src/service/transaction-service.ts
@@ -3,6 +3,7 @@ import { DatabaseError } from "../errors/database-error";
 import {
 	Transaction,
 	ICreateTransaction,
+	IUpdateTransaction,
 } from "../repository/transaction-repository";
 
 export const createNewTransaction = async (req: Request, res: Response) => {
@@ -25,11 +26,42 @@ export const createNewTransaction = async (req: Request, res: Response) => {
 };
 
 export const getAllTransactions = async (req: Request, res: Response) => {
-	const [allTransactions, fetchError] = await Transaction.getAll();
+	const { date } = req.params;
+	const [allTransactions, fetchError] = await Transaction.getAll(date);
 
 	if (fetchError) {
 		throw new DatabaseError(fetchError);
 	}
 
 	res.json(allTransactions);
+};
+
+export const updateTransaction = async (req: Request, res: Response) => {
+	const args = req.body as IUpdateTransaction;
+	const [updatedRows, updateError] = await Transaction.update(req.body);
+
+	if (updateError || updatedRows !== 1) {
+		throw new DatabaseError(updateError);
+	}
+
+	const [[updatedTransaction, _], fetchError] = await Transaction.getOne(
+		args.id
+	);
+
+	if (fetchError) {
+		throw new DatabaseError(fetchError);
+	}
+
+	res.json(updatedTransaction);
+};
+
+export const deleteTransaction = async (req: Request, res: Response) => {
+	const { id } = req.params;
+	const [removedRows, removeError] = await Transaction.delete(parseInt(id));
+
+	if (removeError || removedRows !== 1) {
+		throw new DatabaseError(removeError);
+	}
+
+	res.json("");
 };

--- a/server/src/service/transaction-service.ts
+++ b/server/src/service/transaction-service.ts
@@ -63,5 +63,5 @@ export const deleteTransaction = async (req: Request, res: Response) => {
 		throw new DatabaseError(removeError);
 	}
 
-	res.json("");
+	res.json(id);
 };

--- a/server/src/utils/query-executor.ts
+++ b/server/src/utils/query-executor.ts
@@ -2,67 +2,56 @@ import { promiseHandler } from "./promise-handler";
 import { pool } from "./db-connection-handler";
 
 export type MysqlInsertOrUpdateResult = {
-  fieldCount: number;
-  affectedRows: number;
-  insertId: number;
-  serverStatus: number;
-  warningCount: number;
-  message: string;
-  protocol41: boolean;
-  changedRows: number;
+	fieldCount: number;
+	affectedRows: number;
+	insertId: number;
+	serverStatus: number;
+	warningCount: number;
+	message: string;
+	protocol41: boolean;
+	changedRows: number;
 };
 
 export const selectQueryExecuter = async <T>(
-  query: string
+	query: string
 ): Promise<[T[], any]> => {
-  const conn = await pool.getConnection();
-  const [[result, _], error] = await promiseHandler(conn.query(query));
-  conn.release();
-  return [result as T[], error];
+	const conn = await pool.getConnection();
+	const [[result, _], error] = await promiseHandler(conn.query(query));
+	conn.release();
+	return [result as T[], error];
 };
 
 export const insertQueryExecuter = async (
-  query: string
+	query: string
 ): Promise<[number, any]> => {
-  const conn = await pool.getConnection();
-  const [[{ insertId }, _], error] = await promiseHandler(conn.query(query));
-  conn.release();
-  return [insertId, error];
+	const conn = await pool.getConnection();
+	const [[{ insertId }, _], error] = await promiseHandler(conn.query(query));
+	conn.release();
+	return [insertId, error];
 };
 
 export const updateOrDeleteQueryExecuter = async (
-  query: string
+	query: string
 ): Promise<[number, any]> => {
-  const conn = await pool.getConnection();
-  const [[{ affectedRows }, _], error] = await promiseHandler(
-    conn.query(query)
-  );
-  conn.release();
-  return [affectedRows, error];
+	const conn = await pool.getConnection();
+	const [[{ affectedRows }, _], error] = await promiseHandler(
+		conn.query(query)
+	);
+	conn.release();
+	return [affectedRows, error];
 };
 
-// export const deleteQueryExecuter = async (
-// 	query: string
-// ): Promise<[number, any]> => {
-// 	const conn = await pool.getConnection();
-// 	const [[{ affectedRows }, _], error] = await promiseHandler(
-// 		conn.query(query)
-// 	);
-// 	conn.release();
-// 	return [affectedRows, error];
-// };
-
 export const transactionQueryExecuter = async (...queries: Promise<any>[]) => {
-  const conn = await pool.getConnection();
-  try {
-    conn.beginTransaction();
-    for (const query of queries) {
-      await promiseHandler(query);
-    }
-    conn.commit();
-    return true;
-  } catch (e) {
-    conn.rollback();
-    return false;
-  }
+	const conn = await pool.getConnection();
+	try {
+		conn.beginTransaction();
+		for (const query of queries) {
+			await promiseHandler(query);
+		}
+		conn.commit();
+		return true;
+	} catch (e) {
+		conn.rollback();
+		return false;
+	}
 };


### PR DESCRIPTION
## Describe the feature
- 월 변경에 따른 transaction 데이터 다시 fetch

## Done
- [X] connectAction: 데이터가 아니라 액션만 필요한 경우에 컴포넌트가 해당 api로 스토어와 연결, 이 경우에는 액션이 실행되어도 데이터를 해당컴포넌트 내에서 사용하고 있지 않기 때문에 새로 render할 필요가 없음, connectStore와 분리를 통해 더 효율적인 데이터 관리가 가능해짐
- [X] store -> connectAction 케이스에 따라 새로렌더링할 컴포넌트를 받지 않는 경우를 따로 분리
- [X] Sidebar -> 월 데이터를 변경할 때, 해당 월에 따라 transaction 데이터에 따라 데이터를 다시 fetch
- [X] Icon -> 굳이 필요치 않은 Props를 제거
- [X] transactionStore -> get fetch의 parameter가 변함에 따라, 해당 포멧에 맞게 수정
