### PR TITLE
Bug/76 after routing not working

### DIFF
--- a/client/src/components/App/App.scss
+++ b/client/src/components/App/App.scss
@@ -1,6 +1,5 @@
 @import '../../styles/_variables.scss';
 
 .main-container{
-	padding: 20px 95px;
-
+	padding: 20px 70px 0 140px;
 }

--- a/client/src/components/App/App.ts
+++ b/client/src/components/App/App.ts
@@ -1,7 +1,6 @@
 import { Component } from '../../utils/wooact'
 import { div } from '../../utils/wooact/defaultElements'
-import { Header } from '../Header/index'
-import { routing } from '../../utils/Routing'
+import { RouterComponent } from '../../pages/Router'
 import { FETCH_ALL_TRANSACTION } from '../../modules/TransactionStore'
 import { FETCH_ALL_CATEGORIES } from '../../modules/CategoryStore'
 import { SideBar } from '../SideBar'
@@ -15,38 +14,26 @@ class App extends Component<IProps, IState> {
 
     Object.setPrototypeOf(this, App.prototype)
     this.connectAction('transaction', 'category')
-    routing.init(this)
     this.init()
   }
 
   async componentDidMount() {
     const today = new Date()
-    this.store.transaction.dispatch(FETCH_ALL_TRANSACTION, {
+    const initialDate = {
       month: today.getMonth() + 1,
       year: today.getFullYear(),
+    }
+
+    this.store.transaction.dispatch(FETCH_ALL_TRANSACTION, {
+      ...initialDate,
     })
     this.store.category.dispatch(FETCH_ALL_CATEGORIES)
   }
 
-  getHeaderTitle(rawTitle: string) {
-    const title = rawTitle.slice(1)
-    if (!title) {
-      return 'Transaction'
-    }
-    return title.toUpperCase()[0] + title.slice(1)
-  }
-
   render() {
-    return div(
-      {},
-      new SideBar(),
+    const router = new RouterComponent()
 
-      div(
-        { className: 'main-container' },
-        new Header({ title: this.getHeaderTitle(routing.getPath()) }),
-        routing.getPage()
-      )
-    )
+    return div({}, new SideBar({ routing: router.routing }), router)
   }
 }
 

--- a/client/src/components/CalendarItem/CalendarItem.scss
+++ b/client/src/components/CalendarItem/CalendarItem.scss
@@ -2,4 +2,17 @@
 
 .calendar-item-container{
 	display: flex;
+	flex-direction: column;
+	border: 0.5px solid $hkb-white;
+	padding: 4px;
+
+	.price-container {
+		margin-left: auto;
+		margin-top: auto;
+
+		div {
+			display: flex;
+			justify-content: flex-end;
+		}
+	}
 }

--- a/client/src/components/CalendarItem/CalendarItem.ts
+++ b/client/src/components/CalendarItem/CalendarItem.ts
@@ -2,6 +2,7 @@ import { Component } from '../../utils/wooact'
 import { div } from '../../utils/wooact/defaultElements'
 import { CustomDate } from '../../utils/dateInfos'
 import { ITransactionInfo } from '../../utils/dataFilterer'
+import { getCSVNumber } from '../../utils/getCSVNumber'
 
 interface IProps {
   date: CustomDate
@@ -15,23 +16,38 @@ class CalendarItem extends Component<IProps, IState> {
     super(props)
 
     Object.setPrototypeOf(this, CalendarItem.prototype)
-
-    this.connectStore()
     this.init()
   }
 
-  render() {
-    const { month, date, dayName } = this.props.date
-    let textContnet = `${month}-${date}-${dayName}`
-    if (this.props.transactions) {
-      const { sumOfIncome, sumOfOutcome } = this.props.transactions
-      textContnet += `\n+${sumOfIncome}\n-${sumOfOutcome}`
+  renderSum() {
+    if (!this.props.transactions) {
+      return null
     }
 
-    return div({
-      className: 'calendar-item-container',
-      textContent: textContnet,
-    })
+    const { sumOfIncome, sumOfOutcome } = this.props.transactions
+
+    return div(
+      { className: 'price-container' },
+      sumOfIncome > 0
+        ? div({ className: `income`, textContent: getCSVNumber(sumOfIncome) })
+        : null,
+      sumOfOutcome > 0
+        ? div({ className: `outcome`, textContent: getCSVNumber(sumOfOutcome) })
+        : null
+    )
+  }
+
+  render() {
+    const { date, dayName } = this.props.date
+
+    return div(
+      {
+        className: `calendar-item-container ${dayName}`,
+        // textContent: textContnet,
+      },
+      div({ className: `${dayName}`, textContent: `${date}` }),
+      this.renderSum()
+    )
   }
 }
 

--- a/client/src/components/TransactionList/TransactionList.ts
+++ b/client/src/components/TransactionList/TransactionList.ts
@@ -1,6 +1,5 @@
 import { Component } from '../../utils/wooact'
-import { div, p, data } from '../../utils/wooact/defaultElements'
-import { ITransactionResponse } from '../../api/transaction'
+import { div, p } from '../../utils/wooact/defaultElements'
 import { TransactionItem } from '../TransactionItem'
 import { getCSVNumber } from '../../utils/getCSVNumber'
 import { getRecordedDate, filterByDate } from '../../utils/dataFilterer'
@@ -8,21 +7,12 @@ interface IProps {}
 interface IState {}
 
 class TransactionList extends Component<IProps, IState> {
-  private totalIncome: number
-  private totalOutcome: number
-
   constructor() {
-    const initialState: IState = {
-      transactions: [],
-    }
-    super({}, initialState)
+    super()
 
     Object.setPrototypeOf(this, TransactionList.prototype)
     this.connectStore('transaction', 'visible')
     this.init()
-
-    this.totalIncome = 0
-    this.totalOutcome = 0
   }
 
   renderItems() {
@@ -37,16 +27,20 @@ class TransactionList extends Component<IProps, IState> {
         (visible.income && isIncome) || (visible.outcome && !isIncome)
     )
 
+    console.log(filteredTransaction)
+
     const recordedDates = getRecordedDate(filteredTransaction)
 
     const filteredByDateTransaction = filterByDate(filteredTransaction)
 
-    return recordedDates.map((date, id) => {
+    return recordedDates.map((date) => {
       const {
         transactions,
         sumOfIncome,
         sumOfOutcome,
       } = filteredByDateTransaction[date.toString()]
+
+      // const {} =
       return div(
         { className: 'date-grouped-container' },
         div(
@@ -74,6 +68,7 @@ class TransactionList extends Component<IProps, IState> {
   }
 
   render() {
+    console.log('transaction list re-rendered')
     return div({ className: 'transaction-container' }, ...this.renderItems())
   }
 }

--- a/client/src/modules/DateStore.ts
+++ b/client/src/modules/DateStore.ts
@@ -1,38 +1,53 @@
 import { Store } from '../utils/Store'
-import { fireEvent, STORE_UPDATED } from '../utils/customEventHandler'
 
 export type DateInfo = {
   year: number
   month: number
 }
 // type
-export type Month = number
+const LAST_MONTH = 12
+const FIRST_MONTH = 1
 
 // actions
-export const CHANGE_DATE_INFO = 'Month/CHANGE_DATE_INFO' as const
+export const SET_NEXT_MONTH = 'DateInfo/SET_NEXT_MONTH' as const
+export const SET_PREV_MONTH = 'DateInfo/SET_PREV_MONTH' as const
 
 // connect store and actions
 export class DateStore extends Store<DateInfo> {
   actions = {
-    [CHANGE_DATE_INFO]: this.changeDateInfo,
+    [SET_NEXT_MONTH]: () => this.setNextMonth(),
+    [SET_PREV_MONTH]: () => this.setPrevMonth(),
   }
 
   constructor(initialData: DateInfo) {
     super(initialData)
-    // TODO is this right?
-    // window.dispatchEvent(
-    //   new CustomEvent('storeupdated', { detail: { month: initialData } })
-    // )
   }
 
   // actions
-  changeDateInfo(dateInfo: Partial<DateInfo>) {
-    return dateInfo
+  setNextMonth() {
+    const { year, month } = this.data
+
+    if (month === LAST_MONTH) {
+      return { year: year + 1, month: FIRST_MONTH }
+    }
+    return { month: month + 1 }
+  }
+
+  setPrevMonth() {
+    const { year, month } = this.data
+
+    if (month === FIRST_MONTH) {
+      return { year: year - 1, month: LAST_MONTH }
+    }
+    return { month: month - 1 }
   }
 
   protected updateStore(action: string, result: any) {
     switch (action) {
-      case CHANGE_DATE_INFO:
+      case SET_NEXT_MONTH:
+        this._data = { ...this.data, ...result }
+        break
+      case SET_PREV_MONTH:
         this._data = { ...this.data, ...result }
         break
     }
@@ -40,6 +55,6 @@ export class DateStore extends Store<DateInfo> {
     // window.dispatchEvent(
     //   new CustomEvent('storeupdated', { detail: { month: this.data } })
     // )
-    fireEvent(STORE_UPDATED, { date: this.data })
+    // fireEvent(STORE_UPDATED, { date: this.data })
   }
 }

--- a/client/src/modules/index.ts
+++ b/client/src/modules/index.ts
@@ -2,6 +2,7 @@ import { Store } from '../utils/Store'
 import { TransactionStore } from './TransactionStore'
 import { IVisible, VisibleStore } from './visibleStore'
 import { CategoryStore } from './CategoryStore'
+import { DateInfo, DateStore } from './DateStore'
 import { ITransactionResponse } from '../api/transaction'
 import { ICategoryResponse } from '../api/category'
 
@@ -9,21 +10,23 @@ export interface ICombinedStore {
   transaction: Store<ITransactionResponse[]>
   visible: Store<IVisible>
   category: Store<ICategoryResponse[]>
+  date: Store<DateInfo>
+}
+
+const today = new Date()
+const initialDate = {
+  month: today.getMonth() + 1,
+  year: today.getFullYear(),
 }
 
 const transactionStore = new TransactionStore()
 const visibleStore = new VisibleStore({ income: true, outcome: true })
 const categoryStore = new CategoryStore()
+const dateStore = new DateStore(initialDate)
 
 export const combinedStore: ICombinedStore = {
   transaction: transactionStore,
   visible: visibleStore,
   category: categoryStore,
+  date: dateStore,
 }
-
-// export const combinedStoreData = {
-//   transaction: { updated: false, data: transactionStore.data },
-//   month: { updated: false, data: monthStore.data },
-// }
-
-// fireEvent(STORE_UPDATED, { month: initialMonth })

--- a/client/src/pages/Calendar/Calendar.scss
+++ b/client/src/pages/Calendar/Calendar.scss
@@ -3,7 +3,21 @@
 .calendar-table{
 	display: grid;
 	margin: 0 40px;
-	// width: 90%;
-	grid-template-columns: repeat(7, 1fr);
-	grid-auto-rows: minmax(60px, auto);
+	grid-template-columns: repeat(7, 2fr);
+	grid-auto-rows: minmax(120px, auto);
+
+	.day-eng{
+		margin-top: auto;
+
+		padding-left: 5px;
+		padding-bottom: 10px;
+	}
+
+	.SUN{
+		color: $hkb-red;
+	}
+
+	.SAT{
+		color: $hkb-blue;
+	}
 }

--- a/client/src/pages/Calendar/Calendar.ts
+++ b/client/src/pages/Calendar/Calendar.ts
@@ -1,14 +1,12 @@
 import { Component } from '../../utils/wooact'
-import { div, input, button } from '../../utils/wooact/defaultElements'
+import { div } from '../../utils/wooact/defaultElements'
 import {
   getFullDateIn,
   getFormattedDate,
   DAY_IN_ENG,
-  getDate,
 } from '../../utils/dateInfos'
 import { CalendarItem } from '../../components/CalendarItem'
 import { filterByDate } from '../../utils/dataFilterer'
-import { Header } from '../../components/Header'
 
 interface IProps {}
 interface IState {}
@@ -20,19 +18,17 @@ class Calendar extends Component<IProps, IState> {
     super()
 
     Object.setPrototypeOf(this, Calendar.prototype)
-    this.connectStore('transaction')
+    this.connectStore('transaction', 'date', 'visible')
     this.init()
   }
 
   getFullDate() {
-    const transactions = this.store.transaction.data
-    const dateInfo = getDate(transactions)
-
-    if (!dateInfo) {
+    const date = this.store.date.data
+    if (!date) {
       return []
     }
 
-    const { month, year } = dateInfo
+    const { month, year } = date
     const currentMonth = getFullDateIn(year, month)
     const previousMonth = getFullDateIn(year, month - 1)
     const nextMonth = getFullDateIn(year, month + 1)
@@ -50,7 +46,7 @@ class Calendar extends Component<IProps, IState> {
 
   renderDayInEng() {
     return DAY_IN_ENG.map((eng) =>
-      div({ className: 'day-eng', textContent: eng })
+      div({ className: `day-eng ${eng}`, textContent: eng })
     )
   }
 
@@ -61,11 +57,20 @@ class Calendar extends Component<IProps, IState> {
     }
 
     const transactions = this.store.transaction.data
+
     if (!transactions || transactions.length === 0) {
-      return [null]
+      return fullDate.map((date) => {
+        return new CalendarItem({ date, transactions: null })
+      })
     }
 
-    const filteredByDateTransactions = filterByDate(transactions)
+    const visible = this.store.visible.data
+    const filteredTransaction = transactions.filter(
+      ({ isIncome }) =>
+        (visible.income && isIncome) || (visible.outcome && !isIncome)
+    )
+
+    const filteredByDateTransactions = filterByDate(filteredTransaction)
     return fullDate.map((date) => {
       const keyDate = getFormattedDate(date)
       const transactionsOfDate = filteredByDateTransactions[keyDate]

--- a/client/src/pages/Router.ts
+++ b/client/src/pages/Router.ts
@@ -1,0 +1,50 @@
+import { Component } from '../utils/wooact'
+import { Transaction } from './Transaction'
+import { SignIn } from './SignIn'
+import { Statistics } from './Statistics'
+import { Calendar } from './Calendar'
+import { Routing } from '../utils/Routing'
+import { div } from '../utils/wooact/defaultElements'
+import { Header } from '../components/Header'
+
+export const SIGN_IN = '/sign-in' as const
+export const TRANSACTION = '/' as const
+export const STATISTICS = '/statistics' as const
+export const CALENDAR = '/calendar' as const
+
+interface IProps {}
+interface IState {}
+
+export class RouterComponent extends Component<IProps, IState> {
+  public routing
+
+  constructor() {
+    super()
+
+    Object.setPrototypeOf(this, RouterComponent.prototype)
+    this.routing = new Routing({
+      [TRANSACTION]: Transaction,
+      [SIGN_IN]: SignIn,
+      [STATISTICS]: Statistics,
+      [CALENDAR]: Calendar,
+    })
+    this.routing.init(this)
+    this.init()
+  }
+
+  getHeaderTitle(rawTitle: string) {
+    const title = rawTitle.slice(1)
+    if (!title) {
+      return 'Transaction'
+    }
+    return title.toUpperCase()[0] + title.slice(1)
+  }
+
+  render() {
+    return div(
+      { className: 'main-container' },
+      new Header({ title: this.getHeaderTitle(this.routing.getPath()) }),
+      this.routing.getPage()
+    )
+  }
+}

--- a/client/src/pages/Statistics/Statistics.ts
+++ b/client/src/pages/Statistics/Statistics.ts
@@ -1,6 +1,5 @@
 import { Component } from '../../utils/wooact'
-import { div, input, button } from '../../utils/wooact/defaultElements'
-import { Header } from '../../components/Header'
+import { div } from '../../utils/wooact/defaultElements'
 
 interface IProps {}
 interface IState {}

--- a/client/src/pages/Transaction/Transaction.ts
+++ b/client/src/pages/Transaction/Transaction.ts
@@ -1,8 +1,6 @@
 import { Component } from '../../utils/wooact'
 import { div } from '../../utils/wooact/defaultElements'
-import { AddNewTransaction } from '../../components/AddNewTransaction'
 import { TransactionList } from '../../components/TransactionList'
-import { Header } from '../../components/Header'
 
 interface IProps {}
 interface IState {
@@ -19,11 +17,8 @@ class Transaction extends Component<IProps, IState> {
   }
 
   render() {
-    return div(
-      { className: 'transaction-container' },
-      // new AddNewTransaction({ isAddMode: this.getState('isAddMode') }),
-      new TransactionList()
-    )
+    console.log('transaction rerendered')
+    return div({ className: 'transaction-container' }, new TransactionList())
   }
 }
 

--- a/client/src/utils/Routing.ts
+++ b/client/src/utils/Routing.ts
@@ -7,46 +7,18 @@ import { combinedStore } from '../modules'
 import { listenEvent, STORE_UPDATED } from './customEventHandler'
 
 interface IRoutes {
-  [route: string]: Component<any, any>
+  [route: string]: any
 }
 
-// declare global {
-//   namespace Window {
-//     interface PopStateEvent {
-//       state: ICombinedStore
-//     }
-//   }
-// }
-
-export const SIGN_IN = '/sign-in' as const
-export const TRANSACTION = '/' as const
-export const DEFAULT = '' as const
-export const STATISTICS = '/statistics' as const
-export const CALENDAR = '/calendar' as const
-
-const transactionPage = new Transaction()
-const signInPage = new SignIn()
-const statisticsPage = new Statistics()
-const calendarPage = new Calendar()
-
 export class Routing {
-  private routes: IRoutes = {
-    [TRANSACTION]: transactionPage,
-    [SIGN_IN]: signInPage,
-    [STATISTICS]: statisticsPage,
-    [CALENDAR]: calendarPage,
-  }
-
   private app: Component<any, any>
 
-  constructor() {
+  constructor(private routes: IRoutes) {
     this.popStateHandler = this.popStateHandler.bind(this)
     this.storeUpdatedHandler = this.storeUpdatedHandler.bind(this)
 
     listenEvent(STORE_UPDATED, this.storeUpdatedHandler)
-    // listenEvent(P, this.storeUpdatedHandler)
     window.addEventListener('popstate', this.popStateHandler)
-    // window.addEventListener('storeupdated', this.storeUpdatedHandler)
   }
 
   init(component: Component<any, any>) {
@@ -56,21 +28,21 @@ export class Routing {
   getPath() {
     const path = location.pathname
     if (!this.routes[path]) {
-      return DEFAULT
+      return '/'
     }
 
     return path
   }
 
   getPage(): Component<any, any> {
-    return this.routes[this.getPath()]
+    return new this.routes[this.getPath()]()
   }
 
   pushTo(url: string) {
     const page = this.routes[url]
 
     if (!page) {
-      location.href = DEFAULT
+      location.href = '/'
       this.app.reRenderBy(this)
       return
     }
@@ -98,5 +70,3 @@ export class Routing {
     this.app.reRenderBy(this)
   }
 }
-
-export const routing = new Routing()

--- a/client/src/utils/dateInfos.ts
+++ b/client/src/utils/dateInfos.ts
@@ -28,8 +28,7 @@ export const DAY_IN_ENG = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
 
 export const getFullDateIn = (year: number, month: number): CustomDate[] => {
   const endDate = new Date(year, month, 0).getDate()
-  const startDay = new Date(year, month, 5).getDay()
-
+  const startDay = new Date(year, month - 1, 1).getDay()
   const currentMonthDate = [...Array(endDate)].map((_, i) => i + 1)
 
   return currentMonthDate.map<CustomDate>((date, i) => {


### PR DESCRIPTION
## Describe the feature
- router를 이동한 후에, visibile filter 작동안함

## Done
- router를 app 컴포넌트에서 제거, 동시에 router component를 생성해서 app에 주입, 이로 인해 router 변경이 일어나더라도, app 전체가 아니라 router컴포넌트 내부에서 re-render가 일어남
- 또한 과거에 생성된 view가 라우터간 이동 후에도 남아있어서, 라우터로 이동 후에는 이전 상태의 app이 렌더되어있음. routing 후에 새롭게 컴포넌트를 렌더해서 해당 문제를 해결함
- 캘린더 스타일 및 정보 보여주기 마무리

Resolve #76